### PR TITLE
Don't open binary files as utf8 encoded

### DIFF
--- a/lib/asciidoctor/standoc/blocks.rb
+++ b/lib/asciidoctor/standoc/blocks.rb
@@ -127,7 +127,7 @@ module Asciidoctor
       def datauri(uri)
         types = MIME::Types.type_for(@localdir + uri)
         type = types ? types.first.to_s : 'text/plain; charset="utf-8"'
-        bin = File.read(@localdir + uri, encoding: "utf-8")
+        bin = File.open(@localdir + uri, 'rb') {|io| io.read}
         data = Base64.strict_encode64(bin)
         "data:#{type};base64,#{data}"
       end


### PR DESCRIPTION
Originally comes from https://github.com/riboseinc/metanorma/pull/36

I have found the same issue in this SO post https://stackoverflow.com/questions/3055339/read-contents-of-a-local-file-into-a-variable-in-rails/3055351

I'm not sure about why it works on `Linux` & `OSX`, but I have assumption that both of them use `iconv` native library to deal with unicode, but `Windows` use it's own API (which is part of `WinAPI`) to do `UTF` decoding, if you need more detailed investigation, let me know